### PR TITLE
Added new step to check events gtm.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "behat/mink":   "~1.5"
+    "behat/mink":   "~1.5",
+    "behat/gherkin": "^4.5.1"
   },
   "autoload": {
     "psr-4": {"DennisDigital\\Behat\\Gtm\\": "src"}

--- a/src/Context/GtmContext.php
+++ b/src/Context/GtmContext.php
@@ -99,7 +99,7 @@ class GtmContext extends RawMinkContext {
     }
 
     if (!$this->wildcardMatch($expected_value, $value)) {
-      throw new \Exception('Value ' . $expected_value . ' not found on event ' . $event_name . ', value of property ' . $property . ' is' . $value);
+      throw new \Exception('Value ' . $expected_value . ' not found on event ' . $event_name . ', value of property ' . $property . ' is ' . $value);
     }
   }
 

--- a/src/Context/GtmContext.php
+++ b/src/Context/GtmContext.php
@@ -1,16 +1,20 @@
 <?php
+
 namespace DennisDigital\Behat\Gtm\Context;
 
+use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\MinkExtension\Context\RawMinkContext;
 
 /**
- * Class GtmContext
+ * Class GtmContext.
+ *
  * @package DennisDigital\Behat\Gtm\Context
  */
 class GtmContext extends RawMinkContext {
+
   /**
-   * Check the google tag manager present in the page
+   * Check the google tag manager present in the page.
    *
    * @Given google tag manager id is :arg1
    */
@@ -24,7 +28,7 @@ class GtmContext extends RawMinkContext {
   }
 
   /**
-   * Check google tag manager data layer contain key value pair
+   * Check google tag manager data layer contain key value pair.
    *
    * @Given google tag manager data layer setting :arg1 should be :arg2
    */
@@ -36,7 +40,7 @@ class GtmContext extends RawMinkContext {
   }
 
   /**
-   * Check google tag manager data layer contain key value pair
+   * Check google tag manager data layer contain key value pair.
    *
    * @Given google tag manager data layer setting :arg1 should match :arg2
    */
@@ -48,16 +52,89 @@ class GtmContext extends RawMinkContext {
   }
 
   /**
-   * Get Google Tag Manager Data Layer value
+   * Check google tag manager data layer contain event key value.
    *
-   * @param $key
+   * @Given google tag manager data layer event :event should have the following values:
+   *
+   * Example:
+   * Given google tag manager data layer event "sign_event" should have the following values:
+   *  | eventAction        | eventCategory | eventLabel |
+   *  | behat_gtm_campaign | firma         | F_web      |
+   */
+  public function dataLayerEventShouldHavePropertyValue($event, TableNode $values) {
+    $hash = $values->getHash();
+    $values_array = $hash[0];
+
+    $event_array = $this->getDatalayerEvent($event);
+    foreach ($values_array as $property => $value) {
+      $this->checkDatalayerProperty($event_array, $property, $value);
+    }
+  }
+
+  /**
+   * Check datalayer property value.
+   *
+   * @param array $event_array
+   *   Event array.
+   * @param string $property
+   *   Property datalayer.
+   * @param string $value
+   *   Value datalayer.
+   *
+   * @throws \Exception
+   */
+  public function checkDatalayerProperty(array $event_array, $property, $value) {
+    if (!isset($event_array['event'])) {
+      throw new \Exception('Event not found.');
+    }
+    $event_name = $event_array['event'];
+
+    if (!isset($event_array[$property])) {
+      throw new \Exception('Property ' . $property . ' not found on event ' . $event_name);
+    }
+    if ($event_array[$property] != $value) {
+      throw new \Exception('Value ' . $value . ' not found on event ' . $event_name . ', value of property ' . $property . ' is' . $event_array[$property]);
+    }
+  }
+
+  /**
+   * Obtain datalater event array from event name.
+   *
+   * @param string $event
+   *   Event.
+   *
    * @return mixed
+   *   Event.
+   *
+   * @throws \Exception
+   */
+  protected function getDatalayerEvent($event) {
+    $json_arr = $this->getDataLayerJson();
+
+    // Loop through the array and return the data layer event.
+    foreach ($json_arr as $json_item) {
+      if (isset($json_item['event']) && $json_item['event'] == $event) {
+        return $json_item;
+      }
+    }
+    throw new \Exception('Event' . $event . ' not found.');
+  }
+
+  /**
+   * Get Google Tag Manager Data Layer value.
+   *
+   * @param string $key
+   *   Datalayer key.
+   *
+   * @return mixed
+   *   Datalayer value from key.
+   *
    * @throws \Exception
    */
   protected function getDataLayerValue($key) {
     $json_arr = $this->getDataLayerJson();
 
-    // Loop through the array and return the data layer value
+    // Loop through the array and return the data layer value.
     foreach ($json_arr as $json_item) {
       if (isset($json_item[$key])) {
         return $json_item[$key];
@@ -92,8 +169,8 @@ class GtmContext extends RawMinkContext {
     // Get the html.
     $html = $this->getSession()->getPage()->getContent();
 
-    // Get the dataLayer json and json_decode it
-    preg_match('~dataLayer\s*=\s*(.*?);</script>~' , $html, $match);
+    // Get the dataLayer json and json_decode it.
+    preg_match('~dataLayer\s*=\s*(.*?);</script>~', $html, $match);
     if (!isset($match[0])) {
       throw new \Exception('dataLayer variable not found in source.');
     }
@@ -113,4 +190,5 @@ class GtmContext extends RawMinkContext {
 
     return $json_arr;
   }
+
 }


### PR DESCRIPTION
We added new step to be able to check the properties from an event of gtm.
Please review it.
An example:

```
  # Previous steps to launch the event.
    Given google tag manager data layer event "sign_event" should have the following values:
    | eventAction        | eventCategory | eventLabel |
    | behat_gtm_campaign | firma         | F_web      |
```